### PR TITLE
Update MSFTHUB URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,8 @@ TLDR;
 - [AZ-204 Exam Preparation: Developing Solutions for Microsoft Azure (Cloud Academy)](https://cloudacademy.com/learning-paths/az-204-exam-preparation-developing-solutions-for-microsoft-azure-1208/)
 - [Developing Solutions for Microsoft Azure (AZ-204) - Pluralsight](https://www.pluralsight.com/paths/developing-solutions-for-microsoft-azure-az-204)
 - [AZ-204 Developing Solutions for Microsoft Azure - Udemy](https://www.udemy.com/course/70532-azure/)
-- [Microsoft Certifications Knowledge Hub](https://github.com/mscerts/hub/blob/main/README.md)
+- [Microsoft Certification Hub - AZ-204 Study Materials](https://msfthub.com/azure/az-204/)
 - [Mastering the AZ-204 Exam - A Comprehensive Guide to Azure Certification Preparation](https://programmingwithwolfgang.com/mastering-az-204-exam-comprehensive-guide-azure-certification-preparation)
-- [Knowledge Hub for Microsoft Certifications](https://certs.msfthub.wiki/)
 
 ## Emojis
 


### PR DESCRIPTION
One of the site creators here, updated the URL in README so it points specifically to the AZ-204 study materials (+ to the updated domain)